### PR TITLE
Fix GHA with Rollup for Sample Gallery

### DIFF
--- a/.github/workflows/rollup.yml
+++ b/.github/workflows/rollup.yml
@@ -76,14 +76,8 @@ jobs:
         run: bundle exec htmlproofer ./_site
 
       # Commit changes
-      - name: 💾  Commit rollup changes in doc
+      - name: 🚀  Commit & push changes to gh-pages
         run: |
           git config --local user.name "lwcc-ci"
-          git commit -m "CI: Update Sample Gallery from master" -a
-
-      # Push changes to gh-pages
-      - name: 🚀  Push changes to gh-pages
-        uses: ad-m/github-push-action@master
-        with:
-          branch: 'gh-pages'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git add docs/*
+          git diff-index --quiet HEAD -- || git commit -m "CI: update Sample Gallery from master" -a && git push -f


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed the GitHub Action used to automatically build the sample gallery with Rollup:
- Enable force push to gh-pages protected branch
- Execute the commit and push commands only if there are changes (no changes in the sample gallery should not trigger the commit)

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- gh-pages branch is protected, therefore, we need to force-push the commits from the CI
- If the working directory is empty, the commit command will fail

## How Has This Been Tested?
The changes have been tested from a forked repository:
- Workflow has been modified
- Merge a test PR with changes in the sample gallery: works OK
- Merge a test PR with no changes in the sample gallery: works OK

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
