### PR TITLE
Fix SOQL Date field as label

### DIFF
--- a/force-app/main/default/classes/SOQLDataProvider.cls
+++ b/force-app/main/default/classes/SOQLDataProvider.cls
@@ -76,7 +76,7 @@ public inherited sharing virtual class SOQLDataProvider extends ChartDataProvide
     aChartData.detail = new List<Object>();
 
     for (AggregateResult aResult : Database.query(this.query)) {
-      aChartData.labels.add((String) aResult.get(LABEL_ALIAS));
+      aChartData.labels.add('' + aResult.get(LABEL_ALIAS));
       aChartData.detail.add(aResult.get(VALUE_ALIAS));
     }
 

--- a/force-app/main/default/classes/SOQLDataProviderTest.cls
+++ b/force-app/main/default/classes/SOQLDataProviderTest.cls
@@ -195,6 +195,38 @@ private class SOQLDataProviderTest {
     );
   }
 
+  @isTest
+  static void testGetDataWithBooleanLabel() {
+    insert new Opportunity(
+      CloseDate = date.today().addMonths(2),
+      Name = 'test',
+      StageName = OPPORTUNITY_STAGE_NAME,
+      Amount = OPPORTUNITY_AMOUNT
+    );
+    Test.startTest();
+    final SOQLDataProvider aSOQLDataProvider = new SOQLDataProvider();
+    aSOQLDataProvider.init(
+      'SELECT IsClosed label, SUM(Amount) value FROM Opportunity WITH SECURITY_ENFORCED GROUP BY IsClosed LIMIT 10'
+    );
+    final List<ChartDataProvider.ChartData> chartDatas = aSOQLDataProvider.getData();
+    Test.stopTest();
+    System.assertEquals(
+      new List<String>{ 'false' },
+      chartDatas[0].labels,
+      'chartDatas.label must equals false'
+    );
+    System.assertEquals(
+      OPPORTUNITY_AMOUNT,
+      (Decimal) chartDatas[0].detail[0],
+      'chartDatas.detail must equals ' + OPPORTUNITY_AMOUNT
+    );
+    System.assertEquals(
+      null,
+      chartDatas[0].bgColor,
+      'chartDatas.bgColor must be null'
+    );
+  }
+
   public static final String OPPORTUNITY_STAGE_NAME = 'Prospecting';
   public static final Decimal OPPORTUNITY_AMOUNT = 20;
 }

--- a/force-app/main/default/classes/SOQLDataProviderTest.cls
+++ b/force-app/main/default/classes/SOQLDataProviderTest.cls
@@ -131,7 +131,7 @@ private class SOQLDataProviderTest {
   }
 
   @isTest
-  static void testGetData() {
+  static void testGetDataWithStringLabel() {
     insert new Opportunity(
       CloseDate = date.today().addMonths(2),
       Name = 'test',
@@ -149,6 +149,39 @@ private class SOQLDataProviderTest {
       new List<String>{ OPPORTUNITY_STAGE_NAME },
       chartDatas[0].labels,
       'chartDatas.label must equals ' + OPPORTUNITY_STAGE_NAME
+    );
+    System.assertEquals(
+      OPPORTUNITY_AMOUNT,
+      (Decimal) chartDatas[0].detail[0],
+      'chartDatas.detail must equals ' + OPPORTUNITY_AMOUNT
+    );
+    System.assertEquals(
+      null,
+      chartDatas[0].bgColor,
+      'chartDatas.bgColor must be null'
+    );
+  }
+
+  @isTest
+  static void testGetDataWithDateLabel() {
+    final Date twoMonthFromNow = date.today().addMonths(2);
+    insert new Opportunity(
+      CloseDate = twoMonthFromNow,
+      Name = 'test',
+      StageName = OPPORTUNITY_STAGE_NAME,
+      Amount = OPPORTUNITY_AMOUNT
+    );
+    Test.startTest();
+    final SOQLDataProvider aSOQLDataProvider = new SOQLDataProvider();
+    aSOQLDataProvider.init(
+      'SELECT CloseDate label, SUM(Amount) value FROM Opportunity WHERE IsClosed = false WITH SECURITY_ENFORCED GROUP BY CloseDate LIMIT 10'
+    );
+    final List<ChartDataProvider.ChartData> chartDatas = aSOQLDataProvider.getData();
+    Test.stopTest();
+    System.assertEquals(
+      new List<String>{ '' + twoMonthFromNow },
+      chartDatas[0].labels,
+      'chartDatas.label must equals ' + twoMonthFromNow
     );
     System.assertEquals(
       OPPORTUNITY_AMOUNT,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Use the built in String concatenation implicit conversion mechanism to fix the different type casting for label in the soql query.
Works with String, date, datetime and number

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #24 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test scratch org
Jest test
Apex unit test
Deployment test in scratch org

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
