### PR TITLE
Fix background grid for pie & doughnut charts + hide empty titles

### DIFF
--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.html
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.html
@@ -22,11 +22,13 @@
               ></c-data>
             </template>
           </c-dataset>
-          <c-title
-            text={title}
-            fontfamily="'Salesforce Sans', Arial, sans-serif"
-            fontcolor="rgb(8, 7, 7)"
-          ></c-title>
+          <template if:true={title}>
+            <c-title
+              text={title}
+              fontfamily="'Salesforce Sans', Arial, sans-serif"
+              fontcolor="rgb(8, 7, 7)"
+            ></c-title>
+          </template>
           <c-legend
             position={legendPosition}
             label-fontfamily="'Salesforce Sans', Arial, sans-serif"

--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.html
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.html
@@ -32,16 +32,18 @@
             label-fontfamily="'Salesforce Sans', Arial, sans-serif"
             label-fontcolor="rgb(8, 7, 7)"
           ></c-legend>
-          <template if:false={isRadial}>
-            <c-cartesian-linear-axis
-              axis="y"
-              ticks-beginatzero="true"
-            ></c-cartesian-linear-axis>
-          </template>
-          <template if:true={isRadial}>
-            <c-radial-linear-axis
-              ticks-beginatzero="true"
-            ></c-radial-linear-axis>
+          <template if:false={isCircular}>
+            <template if:false={isRadial}>
+              <c-cartesian-linear-axis
+                axis="y"
+                ticks-beginatzero="true"
+              ></c-cartesian-linear-axis>
+            </template>
+            <template if:true={isRadial}>
+              <c-radial-linear-axis
+                ticks-beginatzero="true"
+              ></c-radial-linear-axis>
+            </template>
           </template>
         </c-chart>
       </template>

--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.js
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.js
@@ -9,12 +9,9 @@ import {
 import getChartData from '@salesforce/apex/ChartBuilderController.getChartData';
 
 const RADIAL_TYPE = [POLARAREA_CHART_TYPE, RADAR_CHART_TYPE];
+const CIRCULAR_TYPE = [DOUGHNUT_CHART_TYPE, PIE_CHART_TYPE];
 
-const DIMENSIONABLE_TYPES = [
-  DOUGHNUT_CHART_TYPE,
-  PIE_CHART_TYPE,
-  ...RADIAL_TYPE
-];
+const DIMENSIONABLE_TYPES = [...CIRCULAR_TYPE, ...RADIAL_TYPE];
 
 export default class ChartBuilder extends LightningElement {
   containerClass = ChartBuilder.DEFAULT_CSS_CLASS;
@@ -146,6 +143,10 @@ export default class ChartBuilder extends LightningElement {
       // pass the custom handler to the getData service from the server
       this._getChartDataHandler(this._handler, this.recordId);
     }
+  }
+
+  get isCircular() {
+    return CIRCULAR_TYPE.includes(this.type);
   }
 
   get isRadial() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove the background grid from App Builder for pie & doughnut charts:
- Don't display the title component in the App Builder if there is no title provided (to avoid an empty space)
![image](https://user-images.githubusercontent.com/6944989/105395137-b592c080-5c1e-11eb-909e-eac955ef2a06.png)

<!--- Describe your changes in detail -->

## Motivation and Context
Problem reported by user via gitter

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Scratch org with different types of charts

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6944989/105395361-ed9a0380-5c1e-11eb-81ba-36d208807dd8.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
