### PR TITLE
Make test data dependent from org

### DIFF
--- a/force-app/main/default/classes/ChartBuilderControllerTest.cls
+++ b/force-app/main/default/classes/ChartBuilderControllerTest.cls
@@ -1,6 +1,8 @@
 @isTest
 private class ChartBuilderControllerTest {
-  static final String OPPORTUNITY_STAGE_NAME = 'Prospecting';
+  static final String OPPORTUNITY_STAGE_NAME = Opportunity.StageName.getDescribe()
+      .getPicklistValues()[0]
+    .getValue();
   static final Decimal OPPORTUNITY_AMOUNT = 20;
   static final String ASSERT_FALSE_MESSAGE = 'Exception thrown should prevent code to reach this point';
 
@@ -16,21 +18,28 @@ private class ChartBuilderControllerTest {
 
   @isTest
   static void testControllerWithSOQL() {
+    Opportunity op = [
+      SELECT Amount, IsClosed, StageName
+      FROM Opportunity
+      LIMIT 1
+    ];
     Test.startTest();
     final List<ChartDataProvider.ChartData> chartDatas = ChartBuilderController.getChartData(
       SOQLDataProvider.class.getName(),
-      'SELECT StageName label, SUM(Amount) value FROM Opportunity WHERE IsClosed = false WITH SECURITY_ENFORCED GROUP BY StageName LIMIT 10'
+      'SELECT StageName label, SUM(Amount) value FROM Opportunity WHERE IsClosed = ' +
+      op.IsClosed +
+      ' WITH SECURITY_ENFORCED GROUP BY StageName LIMIT 10'
     );
     Test.stopTest();
     System.assertEquals(
-      new List<String>{ OPPORTUNITY_STAGE_NAME },
+      new List<String>{ op.StageName },
       chartDatas[0].labels,
-      'chartDatas.label must equals ' + OPPORTUNITY_STAGE_NAME
+      'chartDatas.label must equals ' + op.StageName
     );
     System.assertEquals(
-      OPPORTUNITY_AMOUNT,
+      op.Amount,
       (Decimal) chartDatas[0].detail[0],
-      'chartDatas.detail must equals ' + OPPORTUNITY_AMOUNT
+      'chartDatas.detail must equals ' + op.Amount
     );
     System.assertEquals(
       null,

--- a/force-app/main/default/classes/SOQLDataProviderTest.cls
+++ b/force-app/main/default/classes/SOQLDataProviderTest.cls
@@ -1,6 +1,11 @@
 @isTest
 private class SOQLDataProviderTest {
+  static final String OPPORTUNITY_STAGE_NAME = Opportunity.StageName.getDescribe()
+      .getPicklistValues()[0]
+    .getValue();
+  static final Decimal OPPORTUNITY_AMOUNT = 20;
   static final String ASSERT_FALSE_MESSAGE = 'Exception thrown should prevent code to reach this point';
+
   @isTest
   static void testInit() {
     Test.startTest();
@@ -132,28 +137,37 @@ private class SOQLDataProviderTest {
 
   @isTest
   static void testGetDataWithStringLabel() {
-    insert new Opportunity(
-      CloseDate = date.today().addMonths(2),
+    Opportunity op = new Opportunity(
+      CloseDate = Date.today().addMonths(2),
       Name = 'test',
       StageName = OPPORTUNITY_STAGE_NAME,
       Amount = OPPORTUNITY_AMOUNT
     );
+    insert op;
+    op = [
+      SELECT Amount, IsClosed, StageName
+      FROM Opportunity
+      WHERE Id = :op.Id
+    ];
+
     Test.startTest();
     final SOQLDataProvider aSOQLDataProvider = new SOQLDataProvider();
     aSOQLDataProvider.init(
-      'SELECT StageName label, SUM(Amount) value FROM Opportunity WHERE IsClosed = false WITH SECURITY_ENFORCED GROUP BY StageName LIMIT 10'
+      'SELECT StageName label, SUM(Amount) value FROM Opportunity WHERE IsClosed = ' +
+      op.IsClosed +
+      ' WITH SECURITY_ENFORCED GROUP BY StageName LIMIT 10'
     );
     final List<ChartDataProvider.ChartData> chartDatas = aSOQLDataProvider.getData();
     Test.stopTest();
     System.assertEquals(
-      new List<String>{ OPPORTUNITY_STAGE_NAME },
+      new List<String>{ op.StageName },
       chartDatas[0].labels,
-      'chartDatas.label must equals ' + OPPORTUNITY_STAGE_NAME
+      'chartDatas.label must equals ' + op.StageName
     );
     System.assertEquals(
-      OPPORTUNITY_AMOUNT,
+      op.Amount,
       (Decimal) chartDatas[0].detail[0],
-      'chartDatas.detail must equals ' + OPPORTUNITY_AMOUNT
+      'chartDatas.detail must equals ' + op.Amount
     );
     System.assertEquals(
       null,
@@ -164,29 +178,37 @@ private class SOQLDataProviderTest {
 
   @isTest
   static void testGetDataWithDateLabel() {
-    final Date twoMonthFromNow = date.today().addMonths(2);
-    insert new Opportunity(
-      CloseDate = twoMonthFromNow,
+    Opportunity op = new Opportunity(
+      CloseDate = Date.today().addMonths(2),
       Name = 'test',
       StageName = OPPORTUNITY_STAGE_NAME,
       Amount = OPPORTUNITY_AMOUNT
     );
+    insert op;
+    op = [
+      SELECT Amount, CloseDate, IsClosed
+      FROM Opportunity
+      WHERE Id = :op.Id
+    ];
+
     Test.startTest();
     final SOQLDataProvider aSOQLDataProvider = new SOQLDataProvider();
     aSOQLDataProvider.init(
-      'SELECT CloseDate label, SUM(Amount) value FROM Opportunity WHERE IsClosed = false WITH SECURITY_ENFORCED GROUP BY CloseDate LIMIT 10'
+      'SELECT CloseDate label, SUM(Amount) value FROM Opportunity WHERE IsClosed = ' +
+      op.IsClosed +
+      ' WITH SECURITY_ENFORCED GROUP BY CloseDate LIMIT 10'
     );
     final List<ChartDataProvider.ChartData> chartDatas = aSOQLDataProvider.getData();
     Test.stopTest();
     System.assertEquals(
-      new List<String>{ twoMonthFromNow.format() },
+      new List<String>{ op.CloseDate.format() },
       chartDatas[0].labels,
-      'chartDatas.label must equals ' + twoMonthFromNow.format()
+      'chartDatas.label must equals ' + op.CloseDate.format()
     );
     System.assertEquals(
-      OPPORTUNITY_AMOUNT,
+      op.Amount,
       (Decimal) chartDatas[0].detail[0],
-      'chartDatas.detail must equals ' + OPPORTUNITY_AMOUNT
+      'chartDatas.detail must equals ' + op.Amount
     );
     System.assertEquals(
       null,
@@ -197,12 +219,15 @@ private class SOQLDataProviderTest {
 
   @isTest
   static void testGetDataWithBooleanLabel() {
-    insert new Opportunity(
-      CloseDate = date.today().addMonths(2),
+    Opportunity op = new Opportunity(
+      CloseDate = Date.today().addMonths(2),
       Name = 'test',
       StageName = OPPORTUNITY_STAGE_NAME,
       Amount = OPPORTUNITY_AMOUNT
     );
+    insert op;
+    op = [SELECT Amount, IsClosed FROM Opportunity WHERE Id = :op.Id];
+
     Test.startTest();
     final SOQLDataProvider aSOQLDataProvider = new SOQLDataProvider();
     aSOQLDataProvider.init(
@@ -211,14 +236,14 @@ private class SOQLDataProviderTest {
     final List<ChartDataProvider.ChartData> chartDatas = aSOQLDataProvider.getData();
     Test.stopTest();
     System.assertEquals(
-      new List<String>{ 'false' },
+      new List<String>{ String.valueOf(op.IsClosed) },
       chartDatas[0].labels,
-      'chartDatas.label must equals false'
+      'chartDatas.label must equals ' + op.IsClosed
     );
     System.assertEquals(
-      OPPORTUNITY_AMOUNT,
+      op.Amount,
       (Decimal) chartDatas[0].detail[0],
-      'chartDatas.detail must equals ' + OPPORTUNITY_AMOUNT
+      'chartDatas.detail must equals ' + op.Amount
     );
     System.assertEquals(
       null,
@@ -226,7 +251,4 @@ private class SOQLDataProviderTest {
       'chartDatas.bgColor must be null'
     );
   }
-
-  public static final String OPPORTUNITY_STAGE_NAME = 'Prospecting';
-  public static final Decimal OPPORTUNITY_AMOUNT = 20;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change the values used in test classes to make them dependent from org, instead of using predefined ones.

<!--- Describe your changes in detail -->

## Motivation and Context

Issue #33 - some automations on the opportunity object can make the LWCC tests fails, because the static data might be different now.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Scratch org with on insert Opportunity trigger, running tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
