### PR TITLE
Fix undefined dataset labels issue

### DIFF
--- a/__tests__/unit/chartBuilder.test.js
+++ b/__tests__/unit/chartBuilder.test.js
@@ -111,6 +111,35 @@ describe('test property', () => {
     // Validate parameters of mocked Apex call
     expect(element.soql).toEqual(`'${ChartBuilder.FAKE_ID}'`);
   });
+
+  test('details success', () => {
+    const element = createElement('c-chartBuilder', { is: ChartBuilder });
+    document.body.appendChild(element);
+    const data = [
+      { labels: 'Item1', detail: [1, 2] },
+      { labels: 'Item2', detail: [9, 8] }
+    ];
+    element.details = JSON.stringify(data);
+
+    return flushPromises().then(() => {
+      expect(element.details.length).toEqual(data.length);
+    });
+  });
+
+  test('details success with undefined data removed', () => {
+    const element = createElement('c-chartBuilder', { is: ChartBuilder });
+    document.body.appendChild(element);
+    const data = [
+      { labels: 'Item1', detail: [1, 2] },
+      { labels: 'Item2', detail: [9, 8] },
+      { labels: 'Item3' }
+    ];
+    element.details = JSON.stringify(data);
+
+    return flushPromises().then(() => {
+      expect(element.details.length).toEqual(2);
+    });
+  });
 });
 
 const MOCK_GETCHARTDATA = [{ labels: ['test'], detail: [10] }];

--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.js
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.js
@@ -87,16 +87,18 @@ export default class ChartBuilder extends LightningElement {
           this.dimensionsLabels = this.dimensionsLabels || [
             ...new Set(data.map((x) => x.labels).flat())
           ];
-          this._details = data.map((x, i) => ({
-            detail: x.detail,
-            labels: this._detailsLabels[i],
-            uuid: x.uuid || nanoid(4),
-            bgColor:
-              x.bgColor || this.isDimensionable
-                ? x.detail.map((_, j) => palette[j % palette.length])
-                : palette[i % palette.length],
-            fill: this.fill
-          }));
+          this._details = data
+            .filter((x) => !!x.detail)
+            .map((x, i) => ({
+              detail: x.detail,
+              labels: this._detailsLabels[i],
+              uuid: x.uuid || nanoid(4),
+              bgColor:
+                x.bgColor || this.isDimensionable
+                  ? x.detail.map((_, j) => palette[j % palette.length])
+                  : palette[i % palette.length],
+              fill: this.fill
+            }));
           this.error = false;
         })
         .catch((error) => this.errorCallback(error));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the undefined dataset labels for details with missing data. For the following example, the Item3 label should not be represented in the chart (otherwise it is displayed as undefined)
`[{ labels: 'Item1', detail: [1, 2] }, { labels: 'Item2', detail: [9, 8] }, { labels: 'Item3' }]`

<!--- Describe your changes in detail -->

## Motivation and Context
Open issue #36 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Sratch org + local tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6944989/111762414-4691bb00-88a1-11eb-9835-fb8a8fbf5b37.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
