### PR TITLE
Added app builder configuration for "show legend" to toggle display o…

### DIFF
--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.html
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.html
@@ -31,6 +31,7 @@
           </template>
           <c-legend
             position={legendPosition}
+            display={showLegend}
             label-fontfamily="'Salesforce Sans', Arial, sans-serif"
             label-fontcolor="rgb(8, 7, 7)"
           ></c-legend>

--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.js
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.js
@@ -42,6 +42,9 @@ export default class ChartBuilder extends LightningElement {
   legendPosition;
 
   @api
+  showLegend;
+
+  @api
   colorPalette = 'default';
 
   @api

--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.js-meta.xml
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.js-meta.xml
@@ -50,6 +50,14 @@
         datasource="top,bottom,right,left"
       />
       <property
+        name="showLegend"
+        label="Show Legend"
+        description="Toggle display of the legend on or off"
+        required="false"
+        default="true"
+        type="Boolean"
+      />
+      <property
         name="styleCss"
         label="CSS Style"
         description="Provide inline custom css style for chart container"
@@ -143,6 +151,14 @@
         placeholder="top"
         type="String"
         datasource="top,bottom,right,left"
+      />
+      <property
+        name="showLegend"
+        label="Show Legend"
+        description="Toggle display of the legend on or off"
+        required="false"
+        default="true"
+        type="Boolean"
       />
       <property
         name="styleCss"


### PR DESCRIPTION
…f chart legend

To address concerns which were raised in issue #39 (https://github.com/SalesforceLabs/LightningWebChartJS/issues/39) this feature adds an ability for the app builder to toggle display of the legend on or off.

<!--- Provide a general summary of your changes in the Title above -->

## Description

To address concerns which were raised in issue #39 (https://github.com/SalesforceLabs/LightningWebChartJS/issues/39) this feature adds an ability for the app builder to toggle display of the legend on or off.

<!--- Describe your changes in detail -->

## Motivation and Context

End users were met with undesirable and unintended charts displays when attempting to utilize the app builder component with SOQL statements.

<!--- Why is this change required? What problem does it solve? -->

This change allows for charts made using the app builder to hide the legend when the query returns it as "undefined."

https://github.com/SalesforceLabs/LightningWebChartJS/issues/39

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

The feature has been shown to work across multiple scratch orgs and app builder configurations.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
