### PR TITLE
fix: zero value for min and max ticks

### DIFF
--- a/force-app/main/default/lwc/cartesianAxis/cartesianAxis.js
+++ b/force-app/main/default/lwc/cartesianAxis/cartesianAxis.js
@@ -78,8 +78,7 @@ export default class CartesianAxis extends BaseAxis {
     return this._content.ticks.min;
   }
   set ticksMin(v) {
-    const numberValue = Number(v);
-    this._content.ticks.min = numberValue === 0 ? 0 : numberValue || v;
+    this._content.ticks.min = Number(v);
   }
 
   @api

--- a/force-app/main/default/lwc/cartesianAxis/cartesianAxis.js
+++ b/force-app/main/default/lwc/cartesianAxis/cartesianAxis.js
@@ -86,8 +86,7 @@ export default class CartesianAxis extends BaseAxis {
     return this._content.ticks.max;
   }
   set ticksMax(v) {
-    const numberValue = Number(v);
-    this._content.ticks.max = numberValue === 0 ? 0 : numberValue || v;
+    this._content.ticks.max = Number(v);
   }
 
   @api

--- a/force-app/main/default/lwc/cartesianAxis/cartesianAxis.js
+++ b/force-app/main/default/lwc/cartesianAxis/cartesianAxis.js
@@ -78,7 +78,8 @@ export default class CartesianAxis extends BaseAxis {
     return this._content.ticks.min;
   }
   set ticksMin(v) {
-    this._content.ticks.min = Number(v) || v;
+    const numberValue = Number(v);
+    this._content.ticks.min = numberValue === 0 ? 0 : numberValue || v;
   }
 
   @api
@@ -86,7 +87,8 @@ export default class CartesianAxis extends BaseAxis {
     return this._content.ticks.max;
   }
   set ticksMax(v) {
-    this._content.ticks.max = Number(v) || v;
+    const numberValue = Number(v);
+    this._content.ticks.max = numberValue === 0 ? 0 : numberValue || v;
   }
 
   @api


### PR DESCRIPTION
Fix the case where ticks min/max is zero

## Description

I supported the case for `Number(v) || v `when v is 0. 
## Motivation and Context

I was using the lwcc, and wanted to make the min value as 0, but then realized that it's not working, so I digged into the code and realized that this case is not handled 

## How Has This Been Tested?

Testsed on a chart

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
