### PR TITLE
fix: force casting of numeric attributes in axis

### DIFF
--- a/__tests__/unit/attributes/radialLinearAxis.test.js
+++ b/__tests__/unit/attributes/radialLinearAxis.test.js
@@ -95,22 +95,22 @@ const TEST_DATA_PROPERTIES = [
   ChartOptionMock('tickBeginatzero', true, {
     ticks: { beginAtZero: true }
   }),
-  ChartOptionMock('tickMin', 'foo', { ticks: { min: 'foo' } }),
-  ChartOptionMock('tickMax', 'foo', { ticks: { max: 'foo' } }),
+  ChartOptionMock('tickMin', 1, { ticks: { min: 1 } }),
+  ChartOptionMock('tickMax', 1, { ticks: { max: 1 } }),
   ChartOptionMock('tickMaxtickslimit', 1, {
     ticks: { maxTicksLimit: 1 }
   }),
-  ChartOptionMock('tickPrecision', 'foo', {
-    ticks: { precision: 'foo' }
+  ChartOptionMock('tickPrecision', 1, {
+    ticks: { precision: 1 }
   }),
-  ChartOptionMock('tickStepsize', 'foo', {
-    ticks: { stepSize: 'foo' }
+  ChartOptionMock('tickStepsize', 1, {
+    ticks: { stepSize: 1 }
   }),
-  ChartOptionMock('tickSuggestedmax', 'foo', {
-    ticks: { suggestedMax: 'foo' }
+  ChartOptionMock('tickSuggestedmax', 1, {
+    ticks: { suggestedMax: 1 }
   }),
-  ChartOptionMock('tickSuggestedmin', 'foo', {
-    ticks: { suggestedMin: 'foo' }
+  ChartOptionMock('tickSuggestedmin', 1, {
+    ticks: { suggestedMin: 1 }
   }),
   ChartOptionMock('tickShowlabelbackdrop', true, {
     ticks: { showLabelBackdrop: true }

--- a/force-app/main/default/lwc/radialLinearAxis/radialLinearAxis.js
+++ b/force-app/main/default/lwc/radialLinearAxis/radialLinearAxis.js
@@ -275,7 +275,7 @@ export default class RadialLinearAxis extends RadialAxis {
     return this._payload.ticks.min;
   }
   set tickMin(v) {
-    this._payload.ticks.min = v;
+    this._payload.ticks.min = Number(v);
   }
 
   @api
@@ -283,7 +283,7 @@ export default class RadialLinearAxis extends RadialAxis {
     return this._payload.ticks.max;
   }
   set tickMax(v) {
-    this._payload.ticks.max = v;
+    this._payload.ticks.max = Number(v);
   }
 
   @api
@@ -299,7 +299,7 @@ export default class RadialLinearAxis extends RadialAxis {
     return this._payload.ticks.precision;
   }
   set tickPrecision(v) {
-    this._payload.ticks.precision = v;
+    this._payload.ticks.precision = Number(v);
   }
 
   @api
@@ -307,7 +307,7 @@ export default class RadialLinearAxis extends RadialAxis {
     return this._payload.ticks.stepSize;
   }
   set tickStepsize(v) {
-    this._payload.ticks.stepSize = v;
+    this._payload.ticks.stepSize = Number(v);
   }
 
   @api
@@ -315,7 +315,7 @@ export default class RadialLinearAxis extends RadialAxis {
     return this._payload.ticks.suggestedMax;
   }
   set tickSuggestedmax(v) {
-    this._payload.ticks.suggestedMax = v;
+    this._payload.ticks.suggestedMax = Number(v);
   }
 
   @api
@@ -323,7 +323,7 @@ export default class RadialLinearAxis extends RadialAxis {
     return this._payload.ticks.suggestedMin;
   }
   set tickSuggestedmin(v) {
-    this._payload.ticks.suggestedMin = v;
+    this._payload.ticks.suggestedMin = Number(v);
   }
 
   @api


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Force the casting of numeric attributes in the radial linear axis component. As the charts are composed directly in the HTML, numeric attributes as tickMax will be passed as a string, instead of a number. For example:
```html
      <c-radial-linear-axis tick-max="120"></c-radial-linear-axis>
```

From JS, typeof tickMax === 'string'.

<!--- Describe your changes in detail -->

## Motivation and Context
Closes #82 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Scratch org. Working example:
```html
<c-chart type="radar">
	<c-dataset labels='["Eating", "Drinking", "Sleeping", "Designing", "Coding", "Cycling", "Running"]'>
		<c-data label="My First dataset" detail="[65, 59, 90, 81, 56, 55, 40]" backgroundcolor="rgba(82, 183, 216, 0.2)" bordercolor="rgba(82, 183, 216, 1)" pointhoverbackgroundcolor="#000" pointhoverbordercolor="#000"></c-data>
		<c-data label="My Second dataset" detail="[28, 48, 40, 19, 96, 27, 100]" backgroundcolor="rgba(255, 176, 59, 0.2)" bordercolor="rgba(255, 176, 59, 1)"></c-data>
	</c-dataset>
	<c-title text="Radar Chart"></c-title>
	<c-radial-linear-axis tick-max="120" tick-min="10"></c-radial-linear-axis>
</c-chart>
```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Working example:
![image](https://user-images.githubusercontent.com/6944989/153036386-1322ac3f-8d8c-40e1-a058-df1e080e6ae3.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
