### PR TITLE
Enabling LWCC for namespaced Unlocked package

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@
 
 Contributions are what make the trailblazer community such an amazing place. I regard this component as a way to inspire and learn from others. Any contributions you make are **greatly appreciated**.
 
+## Unlocked package with namespace support
+
+Since the managed package is no longer maintained, you can now take advantage of a namespace'd Unlocked Package alternative.
+Have the Unlocked Package created in your DevHub using a (registered) namespace to isolete the LWCC codebase.
+For that update the sfdx-project.json. The namespace'd Unlocked Package will behave similar to the managed package.
+
 See [contributing.md](/CONTRIBUTING.md) for lwcc principles.
 
 ## Dependencies

--- a/force-app/main/default/lwc/animation/animation.js-meta.xml
+++ b/force-app/main/default/lwc/animation/animation.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/arcConfiguration/arcConfiguration.js-meta.xml
+++ b/force-app/main/default/lwc/arcConfiguration/arcConfiguration.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/baseAttribute/baseAttribute.js-meta.xml
+++ b/force-app/main/default/lwc/baseAttribute/baseAttribute.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/baseAxis/baseAxis.js-meta.xml
+++ b/force-app/main/default/lwc/baseAxis/baseAxis.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/cartesianAxis/cartesianAxis.js-meta.xml
+++ b/force-app/main/default/lwc/cartesianAxis/cartesianAxis.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/cartesianCategoryAxis/cartesianCategoryAxis.js-meta.xml
+++ b/force-app/main/default/lwc/cartesianCategoryAxis/cartesianCategoryAxis.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/cartesianLinearAxis/cartesianLinearAxis.js
+++ b/force-app/main/default/lwc/cartesianLinearAxis/cartesianLinearAxis.js
@@ -55,6 +55,14 @@ export default class CartesianLinearAxis extends CartesianAxis {
     this._content.ticks.suggestedMin = v;
   }
 
+  @api
+  get reverse() {
+    return this._content.ticks.reverse;
+  }
+  set reverse(v) {
+    this._content.ticks.reverse = parseBoolean(v);
+  }
+
   constructor() {
     super();
     this._content.type = CARTESIAN_AXIS_TYPE_LINEAR;

--- a/force-app/main/default/lwc/cartesianLinearAxis/cartesianLinearAxis.js-meta.xml
+++ b/force-app/main/default/lwc/cartesianLinearAxis/cartesianLinearAxis.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/cartesianLogarithmicAxis/cartesianLogarithmicAxis.js-meta.xml
+++ b/force-app/main/default/lwc/cartesianLogarithmicAxis/cartesianLogarithmicAxis.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/cartesianTimeAxis/cartesianTimeAxis.js-meta.xml
+++ b/force-app/main/default/lwc/cartesianTimeAxis/cartesianTimeAxis.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/chart/chart.js-meta.xml
+++ b/force-app/main/default/lwc/chart/chart.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/chartBuilder/chartBuilder.js-meta.xml
+++ b/force-app/main/default/lwc/chartBuilder/chartBuilder.js-meta.xml
@@ -3,7 +3,7 @@
   xmlns="http://soap.sforce.com/2006/04/metadata"
   fqn="timeline"
 >
-  <apiVersion>54.0</apiVersion>
+  <apiVersion>62.0</apiVersion>
   <isExposed>true</isExposed>
   <masterLabel>LWCC App Builder</masterLabel>
   <description

--- a/force-app/main/default/lwc/chartConfigService/chartConfigService.js-meta.xml
+++ b/force-app/main/default/lwc/chartConfigService/chartConfigService.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/constants/constants.js-meta.xml
+++ b/force-app/main/default/lwc/constants/constants.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/constants/constants.js-meta.xml
+++ b/force-app/main/default/lwc/constants/constants.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
-    <isExposed>true</isExposed>
+    <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/data/data.js-meta.xml
+++ b/force-app/main/default/lwc/data/data.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/dataset/dataset.js-meta.xml
+++ b/force-app/main/default/lwc/dataset/dataset.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/layout/layout.js-meta.xml
+++ b/force-app/main/default/lwc/layout/layout.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/legend/legend.js-meta.xml
+++ b/force-app/main/default/lwc/legend/legend.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/lineConfiguration/lineConfiguration.js-meta.xml
+++ b/force-app/main/default/lwc/lineConfiguration/lineConfiguration.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/nanoid/nanoid.js-meta.xml
+++ b/force-app/main/default/lwc/nanoid/nanoid.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/nanoid/nanoid.js-meta.xml
+++ b/force-app/main/default/lwc/nanoid/nanoid.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
-    <isExposed>true</isExposed>
+    <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/pointConfiguration/pointConfiguration.js-meta.xml
+++ b/force-app/main/default/lwc/pointConfiguration/pointConfiguration.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/radialAxis/radialAxis.js-meta.xml
+++ b/force-app/main/default/lwc/radialAxis/radialAxis.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/radialLinearAxis/radialLinearAxis.js-meta.xml
+++ b/force-app/main/default/lwc/radialLinearAxis/radialLinearAxis.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/reactivityManager/reactivityManager.js-meta.xml
+++ b/force-app/main/default/lwc/reactivityManager/reactivityManager.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/reactivityManager/reactivityManager.js-meta.xml
+++ b/force-app/main/default/lwc/reactivityManager/reactivityManager.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
-    <isExposed>true</isExposed>
+    <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/rectangleConfiguration/rectangleConfiguration.js-meta.xml
+++ b/force-app/main/default/lwc/rectangleConfiguration/rectangleConfiguration.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/title/title.js-meta.xml
+++ b/force-app/main/default/lwc/title/title.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/tooltip/tooltip.js-meta.xml
+++ b/force-app/main/default/lwc/tooltip/tooltip.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/utils/utils.js-meta.xml
+++ b/force-app/main/default/lwc/utils/utils.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
-    <isExposed>false</isExposed>
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/utils/utils.js-meta.xml
+++ b/force-app/main/default/lwc/utils/utils.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>62.0</apiVersion>
-    <isExposed>true</isExposed>
+    <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,15 +1,15 @@
 {
   "packageDirectories": [
     {
-      "path": "force-app/main",
-      "default": true
-    },
-    {
-      "path": "force-app/sample",
-      "default": false
+      "versionName": "1.0",
+      "versionNumber": "1.0.0.NEXT",
+      "path": "force-app/main/default",
+      "default": true,
+      "package": "LWCC Unlocked Package",
+      "versionDescription": "LWCC (Lightning Web Chart Component) - Unlocked Package"
     }
   ],
-  "namespace": "",
+  "namespace": "<provide registered namespace>",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "54.0"
+  "sourceApiVersion": "62.0"
 }


### PR DESCRIPTION
## Description
LWCs in package configured with `isExposed=true` to allow creation on namespaced unlocked package.
Added support for `reverse` in `cartesianCategoryAxis`

## Motivation and Context
Allowing to maintain your own unlocked package from the LWCC sources. 

## How Has This Been Tested?
Checked the LWCC LWCs can be used within c/ namespace LWCs.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Updated read.me.
